### PR TITLE
feat(publish): Publish now creates or updates templates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor
 build
 
 .vscode
+.idea

--- a/actions.go
+++ b/actions.go
@@ -66,6 +66,9 @@ func PipelineSaveAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 // templates.
 func PipelineTemplatePublishAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 	return func(cc *cli.Context) error {
+		if cc.Bool("update") {
+			logrus.Warn("The `update` flag is deprecated, `publish` always creates or updates the template")
+		}
 		templateFile := cc.Args().Get(0)
 		logrus.WithField("file", templateFile).Debug("Reading template")
 
@@ -80,7 +83,7 @@ func PipelineTemplatePublishAction(clientConfig spinnaker.ClientConfig) cli.Acti
 		}
 
 		logrus.Info("Publishing template")
-		ref, err := client.PublishTemplate(template, cc.Bool("update"))
+		ref, err := client.PublishTemplate(template)
 		if err != nil {
 			return errors.Wrap(err, "publishing template")
 		}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -45,12 +45,12 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 			Subcommands: []cli.Command{
 				{
 					Name:      "publish",
-					Usage:     "publish a pipeline template",
+					Usage:     "publish a pipeline template, will create or update a template",
 					ArgsUsage: "[template.yml]",
 					Flags: []cli.Flag{
 						cli.BoolFlag{
 							Name:  "update, u",
-							Usage: "update the given pipeline",
+							Usage: "DEPRECATED: update the given pipeline, the default action always creates or updates",
 						},
 					},
 					Before: func(cc *cli.Context) error {


### PR DESCRIPTION
Depreicated the `update` flag on publish. Instead, publish always checks
if the template is already published and creates or updates the template
as needed.