### PR TITLE
Add pipeline delete command

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -308,7 +308,6 @@ func PipelineTemplateDeleteAction(clientConfig spinnaker.ClientConfig) cli.Actio
 
 func PipelineDeleteAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 	return func(cc *cli.Context) error {
-		fmt.Println("woo")
 		app := cc.Args().Get(0)
 		pipelineID := cc.Args().Get(1)
 

--- a/actions.go
+++ b/actions.go
@@ -213,7 +213,6 @@ func PipelineTemplateDeleteAction(clientConfig spinnaker.ClientConfig) cli.Actio
 
 func PipelineDeleteAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 	return func(cc *cli.Context) error {
-		fmt.Println("woo")
 		app := cc.Args().Get(0)
 		pipelineID := cc.Args().Get(1)
 

--- a/actions.go
+++ b/actions.go
@@ -62,6 +62,101 @@ func PipelineSaveAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 	}
 }
 
+func AppCreateAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
+	return func(cc *cli.Context) error {
+		appName := cc.Args().Get(0)
+		ownerEmail := cc.Args().Get(1)
+		logrus.WithField("appName", appName).Debug("Filling in create application task")
+
+		createAppJob := spinnaker.CreateApplicationJob{
+			Application: spinnaker.ApplicationAttributes{
+				Email: ownerEmail,
+				Name:  appName,
+			},
+			Type: "createApplication",
+		}
+		createApp := spinnaker.Task{
+			Application: appName,
+			Description: "Create Application: " + appName,
+			Job:         []interface{}{createAppJob},
+		}
+
+		client, err := clientFromContext(cc, clientConfig)
+		if err != nil {
+			return errors.Wrapf(err, "creating spinnaker client")
+		}
+
+		logrus.Info("Sending create app task")
+		ref, err := client.ApplicationSubmitTask(appName, createApp)
+		if err != nil {
+			return errors.Wrapf(err, "submitting task")
+		}
+
+		resp, err := client.PollTaskStatus(ref.Ref, 1*time.Minute)
+		if err != nil {
+			return errors.Wrap(err, "poll create app status")
+		}
+
+		if resp.Status == "TERMINAL" {
+			logrus.WithField("status", resp.Status).Error("Task failed")
+			if retrofitErr := resp.ExtractRetrofitError(); retrofitErr != nil {
+				prettyPrintJSON([]byte(retrofitErr.ResponseBody))
+			} else {
+				fmt.Printf("%#v\n", resp)
+			}
+		} else {
+			logrus.WithField("status", resp.Status).Info("Task completed")
+		}
+
+		return nil
+	}
+}
+
+func AppGetAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
+	return func(cc *cli.Context) error {
+		appName := cc.Args().Get(0)
+
+		client, err := clientFromContext(cc, clientConfig)
+		if err != nil {
+			return errors.Wrapf(err, "creating spinnaker client")
+		}
+
+		logrus.WithField("appName", appName).Info("Fetching application")
+		exists, appInfo, err := client.ApplicationGet(appName)
+		if err != nil {
+			return errors.Wrap(err, "Fetching app info")
+		}
+
+		if exists == false {
+			fmt.Println("App does not exist or insufficient permission")
+			return fmt.Errorf("Could not fetch app info")
+		}
+		prettyPrintJSON(appInfo)
+		return nil
+	}
+}
+
+func AppListAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
+	return func(cc *cli.Context) error {
+		client, err := clientFromContext(cc, clientConfig)
+		if err != nil {
+			return errors.Wrapf(err, "creating spinnaker client")
+		}
+
+		logrus.Info("Fetching application list")
+
+		appInfo, err := client.ApplicationList()
+		if err != nil {
+			return errors.Wrap(err, "Fetching application list")
+		}
+
+		for _, app := range appInfo {
+			fmt.Println(app.Name)
+		}
+		return nil
+	}
+}
+
 // PipelineTemplatePublishAction creates the ActionFunc for publishing pipeline
 // templates.
 func PipelineTemplatePublishAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {

--- a/actions.go
+++ b/actions.go
@@ -211,6 +211,27 @@ func PipelineTemplateDeleteAction(clientConfig spinnaker.ClientConfig) cli.Actio
 	}
 }
 
+func PipelineDeleteAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
+	return func(cc *cli.Context) error {
+		fmt.Println("woo")
+		app := cc.Args().Get(0)
+		pipelineID := cc.Args().Get(1)
+
+		client, err := clientFromContext(cc, clientConfig)
+		if err != nil {
+			return errors.Wrap(err, "creating spinnaker client")
+		}
+
+		logrus.Info("Deleting pipeline")
+		err = client.DeletePipeline(app, pipelineID)
+		if err != nil {
+			return errors.Wrap(err, "deleting pipeline template")
+		}
+
+		return nil
+	}
+}
+
 func clientFromContext(cc *cli.Context, config spinnaker.ClientConfig) (spinnaker.Client, error) {
 	hc, err := config.HTTPClientFactory(cc)
 	if err != nil {

--- a/actions.go
+++ b/actions.go
@@ -306,6 +306,27 @@ func PipelineTemplateDeleteAction(clientConfig spinnaker.ClientConfig) cli.Actio
 	}
 }
 
+func PipelineDeleteAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
+	return func(cc *cli.Context) error {
+		fmt.Println("woo")
+		app := cc.Args().Get(0)
+		pipelineID := cc.Args().Get(1)
+
+		client, err := clientFromContext(cc, clientConfig)
+		if err != nil {
+			return errors.Wrap(err, "creating spinnaker client")
+		}
+
+		logrus.Info("Deleting pipeline")
+		err = client.DeletePipeline(app, pipelineID)
+		if err != nil {
+			return errors.Wrap(err, "deleting pipeline template")
+		}
+
+		return nil
+	}
+}
+
 func clientFromContext(cc *cli.Context, config spinnaker.ClientConfig) (spinnaker.Client, error) {
 	hc, err := config.HTTPClientFactory(cc)
 	if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,6 +40,41 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 			},
 		},
 		{
+			Name:  "app",
+			Usage: "application tasks",
+			Subcommands: []cli.Command{
+				{
+					Name:      "create",
+					Usage:     "create or update an application",
+					ArgsUsage: "[app name] [owner email]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 2 {
+							return errors.New("both application name and owner email are required")
+						}
+						return nil
+					},
+					Action: roer.AppCreateAction(clientConfig),
+				},
+				{
+					Name:      "get",
+					Usage:     "get info about an application",
+					ArgsUsage: "[app name]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 1 {
+							return errors.New("application name is required")
+						}
+						return nil
+					},
+					Action: roer.AppGetAction(clientConfig),
+				},
+				{
+					Name:   "list",
+					Usage:  "list applications",
+					Action: roer.AppListAction(clientConfig),
+				},
+			},
+		},
+		{
 			Name:  "pipeline-template",
 			Usage: "pipeline template tasks",
 			Subcommands: []cli.Command{

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -37,6 +37,18 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 					},
 					Action: roer.PipelineSaveAction(clientConfig),
 				},
+				{
+					Name:      "delete",
+					Usage:     "delete a pipeline",
+					ArgsUsage: "[application] [pipelineName]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 2 {
+							return errors.New("requires an application and a pipeline")
+						}
+						return nil
+					},
+					Action: roer.PipelineDeleteAction(clientConfig),
+				},
 			},
 		},
 		{

--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -36,6 +36,7 @@ type Client interface {
 	PollTaskStatus(refURL string, timeout time.Duration) (*ExecutionResponse, error)
 	GetPipelineConfig(app, pipelineConfigID string) (*PipelineConfig, error)
 	SavePipelineConfig(pipelineConfig PipelineConfig) error
+	DeletePipeline(app string, pipelineID string) error
 }
 
 type client struct {
@@ -66,6 +67,10 @@ func (c *client) pipelineConfigURL(app, pipelineConfigID string) string {
 
 func (c *client) pipelinesURL() string {
 	return c.endpoint + "/pipelines"
+}
+
+func (c *client) pipelineURL(app string, pipelineID string) string {
+	return fmt.Sprintf( "%s/pipelines/%s/%s", c.endpoint, app, pipelineID)
 }
 
 func (c *client) templateExists(id string) (bool, error) {
@@ -271,6 +276,24 @@ func (c *client) SavePipelineConfig(pipelineConfig PipelineConfig) error {
 		fmt.Println(resp.StatusCode)
 		fmt.Println(string(respBody))
 		return errors.New("plan request failed")
+	}
+
+	return nil
+}
+
+func (c *client) DeletePipeline(app string, pipelineID string) error {
+	url := c.pipelineURL(app, pipelineID)
+	logrus.WithField("pipelineConfigID", pipelineID).Debug("deleting pipeline")
+
+	resp, respBody, err := c.delete(url)
+	if err != nil {
+		return errors.Wrap(err, "delete pipeline config")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println(resp.StatusCode)
+		fmt.Println(string(respBody))
+		return errors.New("delete request failed")
 	}
 
 	return nil

--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -29,6 +29,9 @@ type ClientConfig struct {
 // TODO rz - this interface is pretty bad
 type Client interface {
 	PublishTemplate(template map[string]interface{}, skipPlan bool) (*TaskRefResponse, error)
+	ApplicationSubmitTask(app string, task Task) (*TaskRefResponse, error)
+	ApplicationGet(app string) (bool, []byte, error)
+	ApplicationList() ([]ApplicationInfo, error)
 	Plan(configuration map[string]interface{}, template map[string]interface{}) ([]byte, error)
 	DeleteTemplate(templateID string) (*TaskRefResponse, error)
 	// Run(configuration interface{}) ([]byte, error)
@@ -66,6 +69,18 @@ func (c *client) pipelineConfigURL(app, pipelineConfigID string) string {
 
 func (c *client) pipelinesURL() string {
 	return c.endpoint + "/pipelines"
+}
+
+func (c *client) applicationTasksURL(app string) string {
+	return c.endpoint + fmt.Sprintf("/applications/%s/tasks", app)
+}
+
+func (c *client) applicationURL(app string) string {
+	return c.endpoint + fmt.Sprintf("/applications/%s", app)
+}
+
+func (c *client) applicationsURL() string {
+	return c.endpoint + "/applications"
 }
 
 func (c *client) templateExists(id string) (bool, error) {
@@ -115,6 +130,65 @@ func (c *client) PublishTemplate(template map[string]interface{}, skipPlan bool)
 	}
 
 	return &ref, nil
+}
+
+func (c *client) ApplicationSubmitTask(app string, task Task) (*TaskRefResponse, error) {
+	url := c.applicationTasksURL(app)
+	resp, respBody, err := c.postJSON(url, task)
+	if err != nil {
+		return nil, errors.Wrap(err, "create application submit task")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println(resp.StatusCode)
+		fmt.Println(string(respBody))
+		return nil, errors.New("submit task failed")
+	}
+
+	var ref TaskRefResponse
+	if err := json.Unmarshal(respBody, &ref); err != nil {
+		fmt.Println(string(respBody))
+		return nil, errors.New("unmarshaling task create response")
+	}
+
+	return &ref, nil
+}
+
+func (c *client) ApplicationGet(app string) (bool, []byte, error) {
+	url := c.applicationURL(app)
+	resp, respBody, err := c.getJSON(url)
+	if err != nil {
+		return false, nil, errors.Wrap(err, "unable to get application info")
+	}
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+		return false, nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, nil, errors.New("Unable to determine state of application " + app + ", status: " + strconv.Itoa(resp.StatusCode))
+	}
+
+	return true, respBody, nil
+}
+
+func (c *client) ApplicationList() ([]ApplicationInfo, error) {
+	url := c.applicationsURL()
+	resp, respBody, err := c.getJSON(url)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get application list")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("Unable to fetch application list: " + strconv.Itoa(resp.StatusCode))
+	}
+
+	var appInfo []ApplicationInfo
+	if err := json.Unmarshal(respBody, &appInfo); err != nil {
+		fmt.Println(string(respBody))
+		return nil, errors.New("unmarshaling application list")
+	}
+
+	return appInfo, nil
 }
 
 func (c *client) Plan(configuration map[string]interface{}, template map[string]interface{}) ([]byte, error) {

--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -39,6 +39,7 @@ type Client interface {
 	PollTaskStatus(refURL string, timeout time.Duration) (*ExecutionResponse, error)
 	GetPipelineConfig(app, pipelineConfigID string) (*PipelineConfig, error)
 	SavePipelineConfig(pipelineConfig PipelineConfig) error
+	DeletePipeline(app string, pipelineID string) error
 }
 
 type client struct {
@@ -81,6 +82,10 @@ func (c *client) applicationURL(app string) string {
 
 func (c *client) applicationsURL() string {
 	return c.endpoint + "/applications"
+}
+
+func (c *client) pipelineURL(app string, pipelineID string) string {
+	return fmt.Sprintf("%s/pipelines/%s/%s", c.endpoint, app, pipelineID)
 }
 
 func (c *client) templateExists(id string) (bool, error) {
@@ -345,6 +350,24 @@ func (c *client) SavePipelineConfig(pipelineConfig PipelineConfig) error {
 		fmt.Println(resp.StatusCode)
 		fmt.Println(string(respBody))
 		return errors.New("plan request failed")
+	}
+
+	return nil
+}
+
+func (c *client) DeletePipeline(app string, pipelineID string) error {
+	url := c.pipelineURL(app, pipelineID)
+	logrus.WithField("pipelineConfigID", pipelineID).Debug("deleting pipeline")
+
+	resp, respBody, err := c.delete(url)
+	if err != nil {
+		return errors.Wrap(err, "delete pipeline config")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println(resp.StatusCode)
+		fmt.Println(string(respBody))
+		return errors.New("delete request failed")
 	}
 
 	return nil

--- a/spinnaker/model.go
+++ b/spinnaker/model.go
@@ -33,6 +33,22 @@ type TemplatedPipelineError struct {
 	NestedErrors []TemplatedPipelineError `json:"nestedErrors"`
 }
 
+type Task struct {
+	Application string        `json:"application"`
+	Description string        `json:"description"`
+	Job         []interface{} `json:"job,omitempty""`
+}
+
+type CreateApplicationJob struct {
+	Application ApplicationAttributes `json:"application"`
+	Type        string                `json:"type"`
+}
+
+type ApplicationAttributes struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
 // TaskRefResponse represents a task ID URL response following a submitted
 // orchestration.
 type TaskRefResponse struct {
@@ -115,6 +131,10 @@ type PipelineConfig struct {
 	Notifications        []map[string]interface{} `json:"notifications,omitempty"`
 	LastModifiedBy       string                   `json:"lastModifiedBy"`
 	Config               interface{}              `json:"config,omitempty"`
+}
+
+type ApplicationInfo struct {
+	Name string `json:"name"`
 }
 
 type PipelineLock struct {


### PR DESCRIPTION
Add a pipeline delete command so that you can use `roer` to remove pipelines once you've saved them

This is useful because it allows me to use one interface when doing save and deletes without needing a second binary, and hopefully when config is implemented I would be able to remove my internal shell script wrapping `roer`