### PR TITLE
Application commands

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -129,7 +129,7 @@ func AppGetAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 
 		if exists == false {
 			fmt.Println("App does not exist or insufficient permission")
-			return errors.New("Could not fetch app info")
+			return fmt.Errorf("Could not fetch app info")
 		}
 		prettyPrintJSON(appInfo)
 		return nil

--- a/actions.go
+++ b/actions.go
@@ -136,6 +136,27 @@ func AppGetAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 	}
 }
 
+func AppListAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
+	return func(cc *cli.Context) error {
+		client, err := clientFromContext(cc, clientConfig)
+		if err != nil {
+			return errors.Wrapf(err, "creating spinnaker client")
+		}
+
+		logrus.Info("Fetching application list")
+
+		appInfo, err := client.ApplicationList()
+		if err != nil {
+			return errors.Wrap(err, "Fetching application list")
+		}
+
+		for _, app := range appInfo {
+			fmt.Println(app.Name)
+		}
+		return nil
+	}
+}
+
 // PipelineTemplatePublishAction creates the ActionFunc for publishing pipeline
 // templates.
 func PipelineTemplatePublishAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,6 +40,36 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 			},
 		},
 		{
+			Name:  "app",
+			Usage: "application tasks",
+			Subcommands: []cli.Command{
+				{
+					Name:      "create",
+					Usage:     "create or update an application",
+					ArgsUsage: "[app name] [owner email]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 2 {
+							return errors.New("both application name and owner email are required")
+						}
+						return nil
+					},
+					Action: roer.AppCreateAction(clientConfig),
+				},
+				{
+					Name:      "get",
+					Usage:     "get info about an application",
+					ArgsUsage: "[app name]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 1 {
+							return errors.New("application name is required")
+						}
+						return nil
+					},
+					Action: roer.AppGetAction(clientConfig),
+				},
+			},
+		},
+		{
 			Name:  "pipeline-template",
 			Usage: "pipeline template tasks",
 			Subcommands: []cli.Command{

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -67,6 +67,11 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 					},
 					Action: roer.AppGetAction(clientConfig),
 				},
+				{
+					Name:   "list",
+					Usage:  "list applications",
+					Action: roer.AppListAction(clientConfig),
+				},
 			},
 		},
 		{

--- a/spinnaker/model.go
+++ b/spinnaker/model.go
@@ -133,6 +133,10 @@ type PipelineConfig struct {
 	Config               interface{}              `json:"config,omitempty"`
 }
 
+type ApplicationInfo struct {
+	Name string `json:"name"`
+}
+
 type PipelineLock struct {
 	AllowUnlockUI bool   `json:"allowUnlockUi"`
 	Description   string `json:"description"`

--- a/spinnaker/model.go
+++ b/spinnaker/model.go
@@ -33,6 +33,22 @@ type TemplatedPipelineError struct {
 	NestedErrors []TemplatedPipelineError `json:"nestedErrors"`
 }
 
+type Task struct {
+	Application string        `json:"application"`
+	Description string        `json:"description"`
+	Job         []interface{} `json:"job,omitempty""`
+}
+
+type CreateApplicationJob struct {
+	Application ApplicationAttributes `json:"application"`
+	Type        string                `json:"type"`
+}
+
+type ApplicationAttributes struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
 // TaskRefResponse represents a task ID URL response following a submitted
 // orchestration.
 type TaskRefResponse struct {


### PR DESCRIPTION
Adds a few commands to manipulate and query applications:

- create a new application, uses the minimal info of name and owner email
- list all of the applications, just names
- get details for a single application (just pretty print the JSON)
