### PR TITLE
Added the ability to override the template ID and the source template when publishing

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -178,7 +178,11 @@ func PipelineTemplatePublishAction(clientConfig spinnaker.ClientConfig) cli.Acti
 		}
 
 		logrus.Info("Publishing template")
-		ref, err := client.PublishTemplate(template, cc.Bool("skipPlan"))
+		ref, err := client.PublishTemplate(template, spinnaker.PublishTemplateOptions{
+			SkipPlan:   cc.Bool("skipPlan"),
+			TemplateID: cc.String("templateId"),
+			Source:     cc.String("source"),
+		})
 		if err != nil {
 			return errors.Wrap(err, "publishing template")
 		}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -91,6 +91,14 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 							Name:  "skipPlan, s",
 							Usage: "skip the plan dependent pipelines safety feature",
 						},
+						cli.StringFlag{
+							Name:  "templateId, t",
+							Usage: "override the template ID",
+						},
+						cli.StringFlag{
+							Name:  "source",
+							Usage: "override or add the source template",
+						},
 					},
 					Before: func(cc *cli.Context) error {
 						if cc.NArg() != 1 {

--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -28,7 +28,7 @@ type ClientConfig struct {
 // Client is the Spinnaker API client
 // TODO rz - this interface is pretty bad
 type Client interface {
-	PublishTemplate(template map[string]interface{}, skipPlan bool) (*TaskRefResponse, error)
+	PublishTemplate(template map[string]interface{}, options PublishTemplateOptions) (*TaskRefResponse, error)
 	ApplicationSubmitTask(app string, task Task) (*TaskRefResponse, error)
 	ApplicationGet(app string) (bool, []byte, error)
 	ApplicationList() ([]ApplicationInfo, error)
@@ -98,8 +98,22 @@ func (c *client) templateExists(id string) (bool, error) {
 	return false, errors.New("Unable to determine state of the pipeline template " + id + ", status: " + strconv.Itoa(resp.StatusCode))
 }
 
-func (c *client) PublishTemplate(template map[string]interface{}, skipPlan bool) (*TaskRefResponse, error) {
+type PublishTemplateOptions struct {
+	SkipPlan   bool
+	TemplateID string
+	Source     string
+}
+
+func (c *client) PublishTemplate(template map[string]interface{}, options PublishTemplateOptions) (*TaskRefResponse, error) {
 	url := c.pipelineTemplatesURL()
+	if options.TemplateID != "" {
+		// add the ability to override the template ID when publishing
+		template["id"] = options.TemplateID
+	}
+	if options.Source != "" {
+		// add the ability to override the source template when publishing
+		template["source"] = options.Source
+	}
 	id := template["id"].(string)
 	exists, err := c.templateExists(id)
 	if err != nil {
@@ -108,10 +122,9 @@ func (c *client) PublishTemplate(template map[string]interface{}, skipPlan bool)
 	if exists {
 		url = url + "/" + id
 	}
-	if skipPlan {
+	if options.SkipPlan {
 		url = url + "?skipPlanDependents=true"
 	}
-
 	resp, respBody, err := c.postJSON(url, template)
 	if err != nil {
 		return nil, errors.Wrap(err, "pipeline template publish")


### PR DESCRIPTION
Since versioning or a strategy for slow rollout is not yet available, a CLI option to override the template ID and the source template would be convenient when publishing an existing template without actually modifying its source code.
It coud be published as another template (e.g. `my-template-snapshot` instead of `my-template`) or with another source (e.g. `spinnaker://my-base-snapshot` instead of `spinnaker://my-base`).