### PR TITLE
Additional pipeline commands

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -196,7 +196,7 @@ func PipelineSaveJsonAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc 
 	}
 }
 
-func PipelineListAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
+func PipelineListConfigsAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 	return func(cc *cli.Context) error {
 		appName := cc.Args().Get(0)
 		logrus.WithField("app", appName).Debug("Fetching pipelines")
@@ -206,7 +206,7 @@ func PipelineListAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 			return errors.Wrapf(err, "creating spinnaker client")
 		}
 
-		pipelineInfo, err := client.ListPipeline(appName)
+		pipelineInfo, err := client.ListPipelineConfigs(appName)
 		if err != nil {
 			return errors.Wrap(err, "Fetching pipelines")
 		}
@@ -218,7 +218,7 @@ func PipelineListAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 	}
 }
 
-func PipelineGetAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
+func PipelineGetConfigAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 	return func(cc *cli.Context) error {
 		appName := cc.Args().Get(0)
 		pipelineName := cc.Args().Get(1)

--- a/actions.go
+++ b/actions.go
@@ -240,25 +240,6 @@ func PipelineGetAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 	}
 }
 
-func PipelineDeleteAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
-	return func(cc *cli.Context) error {
-		appName := cc.Args().Get(0)
-		pipelineName := cc.Args().Get(1)
-		logrus.WithField("app", appName).WithField("pipelineName", pipelineName).Debug("Deleting pipeline")
-
-		client, err := clientFromContext(cc, clientConfig)
-		if err != nil {
-			return errors.Wrapf(err, "creating spinnaker client")
-		}
-
-		err = client.DeletePipeline(appName, pipelineName)
-		if err != nil {
-			return errors.Wrap(err, "Deleting pipeline")
-		}
-		return nil
-	}
-}
-
 // PipelineTemplatePublishAction creates the ActionFunc for publishing pipeline
 // templates.
 func PipelineTemplatePublishAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -38,6 +38,18 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 					Action: roer.PipelineSaveAction(clientConfig),
 				},
 				{
+					Name:      "savejson",
+					Usage:     "save a json pipeline configuration",
+					ArgsUsage: "[configuration.json]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 1 {
+							return errors.New("path to json file is required")
+						}
+						return nil
+					},
+					Action: roer.PipelineSaveJsonAction(clientConfig),
+                },
+                {
 					Name:      "delete",
 					Usage:     "delete a pipeline",
 					ArgsUsage: "[application] [pipelineName]",
@@ -83,6 +95,42 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 					Name:   "list",
 					Usage:  "list applications",
 					Action: roer.AppListAction(clientConfig),
+				},
+				{
+					Name:      "pipelines",
+					Usage:     "list all the pipelines in an application",
+					ArgsUsage: "[application name]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 1 {
+							return errors.New("name of application is required")
+						}
+						return nil
+					},
+					Action: roer.PipelineListAction(clientConfig),
+				},
+				{
+					Name:      "delete",
+					Usage:     "removes a pipeline",
+					ArgsUsage: "[application name] [pipeline name]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 2 {
+							return errors.New("both app name and pipeline name are required")
+						}
+						return nil
+					},
+					Action: roer.PipelineDeleteAction(clientConfig),
+				},
+				{
+					Name:      "get",
+					Usage:     "get the config for an individual pipeline",
+					ArgsUsage: "[application name] [pipeline name]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 2 {
+							return errors.New("both app name and pipeline name are required")
+						}
+						return nil
+					},
+					Action: roer.PipelineGetAction(clientConfig),
 				},
 			},
 		},

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -49,6 +49,30 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 					},
 					Action: roer.PipelineSaveJsonAction(clientConfig),
                 },
+				{
+					Name:      "list",
+					Usage:     "list all the pipelines in an application",
+					ArgsUsage: "[application name]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 1 {
+							return errors.New("name of application is required")
+						}
+						return nil
+					},
+					Action: roer.PipelineListAction(clientConfig),
+				},
+				{
+					Name:      "get",
+					Usage:     "get the config for an individual pipeline",
+					ArgsUsage: "[application name] [pipeline name]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 2 {
+							return errors.New("both app name and pipeline name are required")
+						}
+						return nil
+					},
+					Action: roer.PipelineGetAction(clientConfig),
+				},
                 {
 					Name:      "delete",
 					Usage:     "delete a pipeline",
@@ -97,18 +121,6 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 					Action: roer.AppListAction(clientConfig),
 				},
 				{
-					Name:      "pipelines",
-					Usage:     "list all the pipelines in an application",
-					ArgsUsage: "[application name]",
-					Before: func(cc *cli.Context) error {
-						if cc.NArg() != 1 {
-							return errors.New("name of application is required")
-						}
-						return nil
-					},
-					Action: roer.PipelineListAction(clientConfig),
-				},
-				{
 					Name:      "delete",
 					Usage:     "removes a pipeline",
 					ArgsUsage: "[application name] [pipeline name]",
@@ -119,18 +131,6 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 						return nil
 					},
 					Action: roer.PipelineDeleteAction(clientConfig),
-				},
-				{
-					Name:      "get",
-					Usage:     "get the config for an individual pipeline",
-					ArgsUsage: "[application name] [pipeline name]",
-					Before: func(cc *cli.Context) error {
-						if cc.NArg() != 2 {
-							return errors.New("both app name and pipeline name are required")
-						}
-						return nil
-					},
-					Action: roer.PipelineGetAction(clientConfig),
 				},
 			},
 		},

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -59,7 +59,7 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 						}
 						return nil
 					},
-					Action: roer.PipelineListAction(clientConfig),
+					Action: roer.PipelineListConfigsAction(clientConfig),
 				},
 				{
 					Name:      "get",
@@ -71,7 +71,7 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 						}
 						return nil
 					},
-					Action: roer.PipelineGetAction(clientConfig),
+					Action: roer.PipelineGetConfigAction(clientConfig),
 				},
                 {
 					Name:      "delete",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -120,18 +120,6 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 					Usage:  "list applications",
 					Action: roer.AppListAction(clientConfig),
 				},
-				{
-					Name:      "delete",
-					Usage:     "removes a pipeline",
-					ArgsUsage: "[application name] [pipeline name]",
-					Before: func(cc *cli.Context) error {
-						if cc.NArg() != 2 {
-							return errors.New("both app name and pipeline name are required")
-						}
-						return nil
-					},
-					Action: roer.PipelineDeleteAction(clientConfig),
-				},
 			},
 		},
 		{

--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -73,7 +73,6 @@ func (c *client) pipelinesURL() string {
 	return c.endpoint + "/pipelines"
 }
 
-
 func (c *client) applicationTasksURL(app string) string {
 	return c.endpoint + fmt.Sprintf("/applications/%s/tasks", app)
 }

--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -39,7 +39,7 @@ type Client interface {
 	PollTaskStatus(refURL string, timeout time.Duration) (*ExecutionResponse, error)
 	GetPipelineConfig(app, pipelineConfigID string) (*PipelineConfig, error)
 	SavePipelineConfig(pipelineConfig PipelineConfig) error
-	ListPipeline(app string) ([]PipelineConfig, error)
+	ListPipelineConfigs(app string) ([]PipelineConfig, error)
 	DeletePipeline(app, pipelineConfigID string) error
 }
 
@@ -352,7 +352,7 @@ func (c *client) GetPipelineConfig(app, pipelineConfigID string) (*PipelineConfi
 	return &config, nil
 }
 
-func (c *client) ListPipeline(app string) ([]PipelineConfig, error) {
+func (c *client) ListPipelineConfigs(app string) ([]PipelineConfig, error) {
 	url := c.pipelineConfigsURL(app)
 	resp, respBody, err := c.getJSON(url)
 	if err != nil {

--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -39,7 +39,6 @@ type Client interface {
 	PollTaskStatus(refURL string, timeout time.Duration) (*ExecutionResponse, error)
 	GetPipelineConfig(app, pipelineConfigID string) (*PipelineConfig, error)
 	SavePipelineConfig(pipelineConfig PipelineConfig) error
-	DeletePipeline(app string, pipelineID string) error
 	ListPipeline(app string) ([]PipelineConfig, error)
 	DeletePipeline(app, pipelineConfigID string) error
 }
@@ -89,10 +88,6 @@ func (c *client) applicationsURL() string {
 
 func (c *client) pipelineURL(app string, pipelineID string) string {
 	return fmt.Sprintf("%s/pipelines/%s/%s", c.endpoint, app, pipelineID)
-}
-
-func (c *client) pipelineDeleteURL(app, pipelineConfigID string) string {
-	return c.endpoint + fmt.Sprintf("/pipelines/%s/%s", app, pipelineConfigID)
 }
 
 func (c *client) templateExists(id string) (bool, error) {
@@ -356,25 +351,6 @@ func (c *client) GetPipelineConfig(app, pipelineConfigID string) (*PipelineConfi
 	}
 
 	return &config, nil
-}
-
-func (c *client) DeletePipeline(app, pipelineConfigID string) error {
-	url := c.pipelineDeleteURL(app, pipelineConfigID)
-	logrus.WithField("url", url).Debug("deleting pipeline")
-	req, err := http.NewRequest("DELETE", url, nil)
-	if err != nil {
-		return errors.Wrap(err, "Creating delete pipeline request")
-	}
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return errors.Wrap(err, "Requesting pipeline delete")
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("Unexpected return from delete request: " + strconv.Itoa(resp.StatusCode))
-	}
-
-	return nil
 }
 
 func (c *client) ListPipeline(app string) ([]PipelineConfig, error) {

--- a/spinnaker/model.go
+++ b/spinnaker/model.go
@@ -131,6 +131,7 @@ type PipelineConfig struct {
 	Notifications        []map[string]interface{} `json:"notifications,omitempty"`
 	LastModifiedBy       string                   `json:"lastModifiedBy"`
 	Config               interface{}              `json:"config,omitempty"`
+	UpdateTs             string                   `json:"updateTs"`
 }
 
 type ApplicationInfo struct {


### PR DESCRIPTION
Commands for saving a pipeline from raw JSON input, listing all the pipeline in an app, and fetching the config for a pipeline. We've been using this to create pipelines from our automated builds. For PRs and branches we create a dev app and put the pipeline in the dev app. The updated timestamp is in the model pulled for the pipeline cause we cleanup old pipelines if a branch has gone stale and no one is using it. For the most part the client had everything needed, just had expose some commands.