### PR TITLE
A single clean commit of the insecure option.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -239,6 +239,10 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 			Name:  "apiSession, as",
 			Usage: "your active api session",
 		},
+		cli.BoolFlag{
+			Name:  "insecure",
+			Usage: "Bypass TLS certificate validation",
+		},
 	}
 	app.Before = func(cc *cli.Context) error {
 		if cc.GlobalBool("verbose") {

--- a/spinnaker/http.go
+++ b/spinnaker/http.go
@@ -66,6 +66,10 @@ func DefaultHTTPClientFactory(cc *cli.Context) (*http.Client, error) {
 		keyPath = ""
 	}
 
+	c.Transport = &http.Transport{
+        TLSClientConfig: &tls.Config{},
+    }
+
 	if certPath != "" && keyPath != "" {
 		logrus.Debug("Configuring TLS with pem cert/key pair")
 		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
@@ -81,22 +85,14 @@ func DefaultHTTPClientFactory(cc *cli.Context) (*http.Client, error) {
 		clientCertPool := x509.NewCertPool()
 		clientCertPool.AppendCertsFromPEM(clientCA)
 
-		tlsConfig := &tls.Config{
-			MinVersion:               tls.VersionTLS12,
-			PreferServerCipherSuites: true,
-			Certificates:             []tls.Certificate{cert},
-			// TODO rz - Add support for self-signed certs; this doesn't work
-			// RootCAs:                  clientCertPool,
-			InsecureSkipVerify: true,
-		}
-
-		c.Transport = &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
+		c.Transport.(*http.Transport).TLSClientConfig.MinVersion = tls.VersionTLS12
+		c.Transport.(*http.Transport).TLSClientConfig.PreferServerCipherSuites = true
+		c.Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{cert}
+		c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
 	}
 
-	if c.Transport == nil {
-		logrus.Warn("HTTP client not configured with TLS transport")
+	if cc.GlobalIsSet("insecure") {
+	    c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	return &c, nil


### PR DESCRIPTION
Adding this because spinnaker gate doesn't seem to be sending the intermediate certificates, which prevents validation of our known good certificates.