### PR TITLE
Fiat auth options clean

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -418,7 +418,18 @@ func clientFromContext(cc *cli.Context, config spinnaker.ClientConfig) (spinnake
 	if err != nil {
 		return nil, errors.Wrap(err, "creating http client from context")
 	}
-	return spinnaker.New(config.Endpoint, hc), nil
+	
+	var sc spinnaker.Client
+	sc = spinnaker.New(config.Endpoint, hc)
+	
+	if cc.GlobalIsSet("fiatUser") && cc.GlobalIsSet("fiatPass") {
+	    err := sc.FiatLogin(cc.GlobalString("fiatUser"), cc.GlobalString("fiatPass"))
+	    if err != nil {
+	        return nil, errors.Wrap(err, "fiat auth login attempt")
+	    }
+	}
+	
+	return sc, nil
 }
 
 func readYamlFile(f string) (map[string]interface{}, error) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -239,6 +239,14 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 			Name:  "apiSession, as",
 			Usage: "your active api session",
 		},
+		cli.StringFlag{
+			Name:  "fiatUser",
+			Usage: "Username for Fiat auth",
+		},
+		cli.StringFlag{
+			Name:  "fiatPass",
+			Usage: "Password for Fiat auth",
+		},
 	}
 	app.Before = func(cc *cli.Context) error {
 		if cc.GlobalBool("verbose") {

--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"strconv"
@@ -41,6 +42,7 @@ type Client interface {
 	SavePipelineConfig(pipelineConfig PipelineConfig) error
 	ListPipelineConfigs(app string) ([]PipelineConfig, error)
 	DeletePipeline(app, pipelineConfigID string) error
+	FiatLogin(fiatUser string, fiatPass string) error
 }
 
 type client struct {
@@ -87,6 +89,10 @@ func (c *client) applicationsURL() string {
 
 func (c *client) pipelineURL(app string, pipelineID string) string {
 	return fmt.Sprintf("%s/pipelines/%s/%s", c.endpoint, app, pipelineID)
+}
+
+func (c *client) fiatLoginURL() string {
+    return c.endpoint + "/login"
 }
 
 func (c *client) templateExists(id string) (bool, error) {
@@ -405,4 +411,17 @@ func (c *client) DeletePipeline(app string, pipelineID string) error {
 	}
 
 	return nil
+}
+
+func (c *client) FiatLogin(fiatUser string, fiatPass string) error {
+    postURL := c.fiatLoginURL()
+    
+    data := url.Values{"username": {fiatUser}, "password": {fiatPass}, "submit": {"Login"}}
+    
+    _, _, err := c.postForm(postUrl, data)
+    if err != nil {
+        return errors.Wrap(err, "fiat login")
+    }
+    
+    return nil
 }

--- a/spinnaker/http.go
+++ b/spinnaker/http.go
@@ -27,9 +27,9 @@ func DefaultHTTPClientFactory(cc *cli.Context) (*http.Client, error) {
 		logrus.Panic("cli context has not been set")
 	}
 	var c http.Client
+    cookieJar, _ := cookiejar.New(nil)
 
 	if cc.GlobalIsSet("apiSession") {
-		cookieJar, _ := cookiejar.New(nil)
 		var cookies []*http.Cookie
 		cookie := &http.Cookie{
 			Name:  "SESSION",
@@ -38,15 +38,12 @@ func DefaultHTTPClientFactory(cc *cli.Context) (*http.Client, error) {
 		cookies = append(cookies, cookie)
 		u, _ := url.Parse(os.Getenv("SPINNAKER_API"))
 		cookieJar.SetCookies(u, cookies)
-		c = http.Client{
-			Timeout: 10 * time.Second,
-			Jar:     cookieJar,
-		}
-	} else {
-		c = http.Client{
-			Timeout: 10 * time.Second,
-		}
 	}
+
+    c = http.Client{
+        Timeout: 10 * time.Second,
+        Jar:     cookieJar,
+    }
 
 	var certPath string
 	var keyPath string
@@ -125,6 +122,26 @@ func (c *client) postJSON(url string, body interface{}) (resp *http.Response, re
 	}
 
 	return resp, respBody, nil
+}
+
+func (c *client) postForm(url string, data url.Values) (resp *http.Response, respBody []byte, err error) {
+    resp, err = c.httpClient.PostForm(url, data)
+    if err != nil {
+        return nil, nil, errors.Wrapf(err, "posting to %s", url)
+    }
+
+    defer func() {
+        if cerr := resp.Body.Close(); cerr != nil && err != nil {
+            err = errors.Wrapf(err, "failed to close response body from %s", url)
+        }
+    }()
+
+    respBody, err = ioutil.ReadAll(resp.Body)
+    if err != nil {
+        return nil, nil, errors.Wrapf(err, "failed to read response body from url %s", url)
+    }
+
+    return resp, respBody, nil
 }
 
 func (c *client) getJSON(url string) (resp *http.Response, respBody []byte, err error) {


### PR DESCRIPTION
A single clean commit of the fiat auth options. Adding these because we have LDAP login via fiat and roer has no mechanism to use this. Copying the session-id from a browser session is untenable for day to day development.