### PR TITLE
Fix typo 'postUrl' variable to 'postURL' and gofmt

### DIFF
--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -92,7 +92,7 @@ func (c *client) pipelineURL(app string, pipelineID string) string {
 }
 
 func (c *client) fiatLoginURL() string {
-    return c.endpoint + "/login"
+	return c.endpoint + "/login"
 }
 
 func (c *client) templateExists(id string) (bool, error) {
@@ -414,14 +414,14 @@ func (c *client) DeletePipeline(app string, pipelineID string) error {
 }
 
 func (c *client) FiatLogin(fiatUser string, fiatPass string) error {
-    postURL := c.fiatLoginURL()
-    
-    data := url.Values{"username": {fiatUser}, "password": {fiatPass}, "submit": {"Login"}}
-    
-    _, _, err := c.postForm(postUrl, data)
-    if err != nil {
-        return errors.Wrap(err, "fiat login")
-    }
-    
-    return nil
+	postURL := c.fiatLoginURL()
+
+	data := url.Values{"username": {fiatUser}, "password": {fiatPass}, "submit": {"Login"}}
+
+	_, _, err := c.postForm(postURL, data)
+	if err != nil {
+		return errors.Wrap(err, "fiat login")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fix typo `postUrl` variable to `postURL`, and apply gofmt.
Now can't building `roer` binary because occur following error:

```sh
# github.com/spinnaker/roer/spinnaker
spinnaker/client.go:421:29: undefined: postUrl
```

related: https://github.com/spinnaker/roer/pull/23