### PR TITLE
Give feedback when roer encounters an error

### DIFF
--- a/cmd/roer/main.go
+++ b/cmd/roer/main.go
@@ -23,6 +23,7 @@ func main() {
 		HTTPClientFactory: spinnaker.DefaultHTTPClientFactory,
 	}
 	if err := cmd.NewRoer(version, config).Run(os.Args); err != nil {
+		logrus.Errorf("Error: %s", err.Error())
 		os.Exit(1)
 	}
 }

--- a/cmd/roer/main.go
+++ b/cmd/roer/main.go
@@ -23,7 +23,6 @@ func main() {
 		HTTPClientFactory: spinnaker.DefaultHTTPClientFactory,
 	}
 	if err := cmd.NewRoer(version, config).Run(os.Args); err != nil {
-		logrus.Error(err.Error())
-		os.Exit(1)
+		logrus.Fatal(err.Error())
 	}
 }

--- a/cmd/roer/main.go
+++ b/cmd/roer/main.go
@@ -23,7 +23,7 @@ func main() {
 		HTTPClientFactory: spinnaker.DefaultHTTPClientFactory,
 	}
 	if err := cmd.NewRoer(version, config).Run(os.Args); err != nil {
-		logrus.Errorf("Error: %s", err.Error())
+		logrus.Error(err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This should provide slightly better feedback when an error happens upstream, say when a template doesn't parse correctly. 

Prior to this, roer would exit with no feedback when an error was raised. No errors from upstream actions were presented because they were merely returned, then swallowed in `main()`.