### PR TITLE
Application Lifecycle Management

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -68,6 +68,7 @@ func AppCreateAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 		appName := cc.Args().Get(0)
 		configFile := cc.Args().Get(1)
 
+		logrus.WithField("appName", appName).Debug("Filling in create application task")
 		logrus.WithField("file", configFile).Debug("Reading application config")
 
 		config, err := readYamlFile(configFile)

--- a/actions.go
+++ b/actions.go
@@ -75,9 +75,7 @@ func AppCreateAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 			return errors.Wrapf(err, "reading config file: %s", configFile)
 		}
 
-		if _, ok := config["name"]; ok {
-			config["name"] = appName
-		}
+		config["name"] = appName
 
 		createAppJob := spinnaker.ApplicationJob{
 			Application: config,

--- a/actions.go
+++ b/actions.go
@@ -152,7 +152,7 @@ func AppDeleteAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 			return errors.Wrapf(err, "submitting task")
 		}
 
-		resp, err := client.PollTaskStatus(ref.Ref, 1*time.Minute)
+		resp, err := client.PollTaskStatus(ref.Ref, time.Duration(cc.GlobalInt("timeout"))*time.Second)
 		if err != nil {
 			return errors.Wrap(err, "poll delete app status")
 		}

--- a/actions.go
+++ b/actions.go
@@ -75,7 +75,9 @@ func AppCreateAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 			return errors.Wrapf(err, "reading config file: %s", configFile)
 		}
 
-		config["name"] = appName
+		if _, ok := config["name"]; ok {
+			config["name"] = appName
+		}
 
 		createAppJob := spinnaker.ApplicationJob{
 			Application: config,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -93,14 +93,26 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 				{
 					Name:      "create",
 					Usage:     "create or update an application",
-					ArgsUsage: "[app name] [owner email]",
+					ArgsUsage: "[app name] [config.yml]",
 					Before: func(cc *cli.Context) error {
 						if cc.NArg() != 2 {
-							return errors.New("both application name and owner email are required")
+							return errors.New("both application name and configuration are required")
 						}
 						return nil
 					},
 					Action: roer.AppCreateAction(clientConfig),
+				},
+				{
+					Name:      "delete",
+					Usage:     "delete an application",
+					ArgsUsage: "[app name]",
+					Before: func(cc *cli.Context) error {
+						if cc.NArg() != 1 {
+							return errors.New("application name is required")
+						}
+						return nil
+					},
+					Action: roer.AppDeleteAction(clientConfig),
 				},
 				{
 					Name:      "get",

--- a/examples/testapp.yml
+++ b/examples/testapp.yml
@@ -1,0 +1,15 @@
+---
+# set application config here
+# the `name` key does not need to be set
+# and will be overridden by the name cli arg
+email: test@email.com
+cloudProviders:
+  - aws
+repoType: github
+repoProjectKey: testapp
+instancePort: 81
+providerSettings:
+  aws:
+    useAmiBlockDeviceMappings: false
+  gcp:
+    associatePublicIpAddress: false

--- a/spinnaker/model.go
+++ b/spinnaker/model.go
@@ -39,9 +39,9 @@ type Task struct {
 	Job         []interface{} `json:"job,omitempty""`
 }
 
-type CreateApplicationJob struct {
-	Application ApplicationAttributes `json:"application"`
-	Type        string                `json:"type"`
+type ApplicationJob struct {
+	Application map[string]interface{} `json:"application"`
+	Type        string                 `json:"type"`
 }
 
 type ApplicationAttributes struct {


### PR DESCRIPTION
This PR makes it so the application lifecycle can be managed completely. The user can now create an application configuration and then create an application in spinnaker based off of it. Additionally, this allows existing applications to be updated. Lastly, this implements a delete operation for applications, which does as its name suggests.

- Allows applications to be codified
  - This does no validation of the application document
  - Poorly formed configs will fail at the API
- Refactor `CreateApplicationJob` to be more generic `ApplicationJob`
- Add example application config
- Implement delete application feature