### PR TITLE
fix(output): Refactor output for some actions

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -192,7 +192,11 @@ func AppGetAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 			logrus.Error("App does not exist or insufficient permission")
 			return fmt.Errorf("Could not fetch app info")
 		}
-		prettyPrintJSON(appInfo)
+		appYaml, err := yaml.JSONToYAML(appInfo)
+		if err != nil {
+			return fmt.Errorf("could not unmarshal: %v", err)
+		}
+		fmt.Println(appYaml)
 		return nil
 	}
 }
@@ -213,7 +217,7 @@ func AppListAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 		}
 
 		for _, app := range appInfo {
-			logrus.Debug(app.Name)
+			logrus.Info(app.Name)
 		}
 
 		return nil
@@ -274,7 +278,7 @@ func PipelineListConfigsAction(clientConfig spinnaker.ClientConfig) cli.ActionFu
 		}
 
 		for _, pipeline := range pipelineInfo {
-			logrus.Debug(pipeline.Name)
+			logrus.Info(pipeline.Name)
 		}
 		return nil
 	}
@@ -298,7 +302,7 @@ func PipelineGetConfigAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc
 		}
 
 		jsonStr, _ := json.Marshal(pipelineConfig)
-		logrus.Debug(string(jsonStr))
+		prettyPrintJSON(jsonStr)
 		return nil
 	}
 }
@@ -379,7 +383,7 @@ func PipelineTemplatePlanAction(clientConfig spinnaker.ClientConfig) cli.ActionF
 				prettyPrintJSON(resp)
 				return nil
 			}
-			logrus.Debug(string(resp))
+			logrus.Info(string(resp))
 			return errors.Wrap(err, "planning configuration")
 		}
 
@@ -416,8 +420,8 @@ func PipelineTemplateConvertAction(clientConfig spinnaker.ClientConfig) cli.Acti
 			return errors.Wrap(err, "marshaling template to YAML")
 		}
 
-		logrus.Debug(generatedTemplateHeader)
-		logrus.Debug(string(template))
+		logrus.Info(generatedTemplateHeader)
+		logrus.Info(string(template))
 
 		return nil
 	}


### PR DESCRIPTION
There are a few improvements or fixes here. Looks like I might have become a bit overzealous in my last PR with the debug output, so this hopes to correct some of that. This also proposes outputting the application config in YAML, since that is the format roer takes in. Lastly, this also proposes using the built-in `prettyPrintJson` function to output pipeline configs in nicely formatted JSON.

- Output app config in YAML since that is what it takes
- Change some output from `Debug` to `Info` where needed
- Pretty print pipeline get output