### PR TITLE
Fix YAML output

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -245,7 +245,7 @@ func AppGetAction(clientConfig spinnaker.ClientConfig) cli.ActionFunc {
 		if err != nil {
 			return fmt.Errorf("could not unmarshal: %v", err)
 		}
-		fmt.Println(appYaml)
+		fmt.Printf("%s", appYaml)
 		return nil
 	}
 }


### PR DESCRIPTION
 Ugh, fixing more of my own bugs. This will print the YAML as a string, instead of the bytes slice.