### PR TITLE
Add ArgsUsage to template's delete command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -225,9 +225,9 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 					Action: roer.PipelineTemplateConvertAction(clientConfig),
 				},
 				{
-					Name:  "delete",
-					Usage: "deletes a pipeline template",
-					ArgsUsage: "[templateId]"
+					Name:      "delete",
+					Usage:     "deletes a pipeline template",
+					ArgsUsage: "[templateId]",
 					Flags: []cli.Flag{
 						cli.StringFlag{
 							Name:  "id",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -227,6 +227,7 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 				{
 					Name:  "delete",
 					Usage: "deletes a pipeline template",
+					ArgsUsage: "[templateId]"
 					Flags: []cli.Flag{
 						cli.StringFlag{
 							Name:  "id",


### PR DESCRIPTION
Although the `pipeline-template delete` command specify the template by id which is require, there was no `ArgsUsage`.

I added this for better feedback.