### PR TITLE
Added support for IAP to roer

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -285,6 +285,10 @@ func NewRoer(version string, clientConfig spinnaker.ClientConfig) *cli.App {
 			Name:  "apiSession, as",
 			Usage: "your active api session",
 		},
+		cli.StringFlag{
+			Name:  "iapToken, iap",
+			Usage: "your IAP bearer token",
+		},
 		cli.BoolFlag{
 			Name:  "insecure",
 			Usage: "Bypass TLS certificate validation",

--- a/spinnaker/client.go
+++ b/spinnaker/client.go
@@ -294,7 +294,7 @@ func (c *client) DeleteTemplate(templateID string) (*TaskRefResponse, error) {
 }
 
 func (c *client) GetTask(refURL string) (*ExecutionResponse, error) {
-	resp, err := c.httpClient.Get(c.endpoint + refURL)
+	resp, err := c.Get(c.endpoint + refURL)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "getting task status")
@@ -359,7 +359,7 @@ func (c *client) PollTaskStatus(refURL string, timeout time.Duration) (*Executio
 func (c *client) GetPipelineConfig(app, pipelineConfigID string) (*PipelineConfig, error) {
 	url := c.pipelineConfigURL(app, pipelineConfigID)
 	logrus.WithField("url", url).Debug("getting url")
-	resp, err := c.httpClient.Get(url)
+	resp, err := c.Get(url)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "getting pipeline config")


### PR DESCRIPTION
In order to work with roer using IAP, I've added this support.

It works either by setting a flag --iap and pasting the bearer token, or having the bearer token in environment variable $SPINNAKER_IAP_TOKEN.

In order to generate the token, there are several ways, either by using a service account JSON file, or by oauth web authentication with client ID and secret. 
It's out of this code's scope, and therefore not added. 